### PR TITLE
Old generate extreme conflicts when build PA, P.A.C. or other was use .d...

### DIFF
--- a/cm.dependencies
+++ b/cm.dependencies
@@ -1,7 +1,8 @@
 [
  {
-   "repository": "lge-kernel-p700",
+   "account": "TeamHackLG"
+   "repository": "lge-kernel-lproj",
    "target_path": "kernel/lge/msm7x27a-common",
-   "branch": "android-msm-3.4"
+   "branch": "android-msm-3.4-jb42"
  }
 ]


### PR DESCRIPTION
...ependecies.

Best way when delete this file. would not used for build
